### PR TITLE
fix URL suffix trimming

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -47,8 +47,8 @@ type GraphQL struct {
 // against the specified url. The url represents a fully qualified URL without
 // the `graphql` endpoint attached. If `/graphql` is provided, it's trimmed off.
 func New(url string, options ...func(gql *GraphQL)) *GraphQL {
-	url = strings.TrimRight(url, "/graphql")
-	url = strings.TrimRight(url, "/") + "/"
+	url = strings.TrimSuffix(url, "/graphql")
+	url = strings.TrimSuffix(url, "/") + "/"
 
 	gql := GraphQL{
 		url:     url,


### PR DESCRIPTION
`strings.TrimRight` removes istances of unicode code points in the cutset from the right end of the string, while the intention here is to remove the "/graphql" suffix; `strings.TrimSuffix` does this.

Please take a look.